### PR TITLE
GLOBALNOMAD #30 폴더구조 및 컴포넌트 이름 변경(스타일 통일)

### DIFF
--- a/src/components/rating/Rating.css.ts
+++ b/src/components/rating/Rating.css.ts
@@ -1,7 +1,7 @@
 import { style } from '@vanilla-extract/css';
 import { global } from '@/styles/global.css';
 
-export const ratings = style({
+export const rating = style({
   display: 'flex',
   alignItems: 'center',
   gap: '0.5rem',

--- a/src/components/rating/Rating.tsx
+++ b/src/components/rating/Rating.tsx
@@ -1,14 +1,14 @@
 import StarFill from '@/assets/icons/star-fill.svg';
-import * as styles from './Ratings.css';
+import * as styles from './Rating.css';
 
 // 사용법: <Ratings rating={item.rating} reviewCount={item.reviewCount} darkMode small />
 
 // dark mode: 기본은 defaultMode 검은글씨, darkMode 설정하면 흰글씨(true).
 // small: 기본은 16px, small 설정하면 14px(true).
 
-export default function Ratings(props: { rating: number; reviewCount: number; darkMode?: boolean; small?: boolean }) {
+export default function Rating(props: { rating: number; reviewCount: number; darkMode?: boolean; small?: boolean }) {
   return (
-    <div className={styles.ratings}>
+    <div className={styles.rating}>
       <StarFill className={props.small ? styles.smallIcon : styles.defaultIcon} />
       <div className={props.darkMode ? styles.darkModeText : styles.defaultModeText}>
         <div className={props.small ? styles.smallSizeText : styles.defaultSizeText}>


### PR DESCRIPTION
## 작업 목적
기존에 개발한 공용 별점 컴포넌트의 폴더구조나 네이밍이 다른분들 스타일과 맞지 않아서 수정했습니다
기존 PR을 머지시킨 후에 발견해서 별도 PR로 올립니다

## 작업 내용
- [x]  /components/rating 폴더 생성
- [x] 컴포넌트 이름 단수형으로 변경


## 첨부
![image](https://github.com/user-attachments/assets/20d7b3fb-7b36-4ffe-9d8e-77e898853fc0)


## 관련된 이슈, 커밋, PR
- PR #19 
- ISSUE #30 

## 체크리스트

- [x] 빌드 테스트는 하셨나요?
- [x] PR의 내용을 짐작할 수 있는 적절한 제목을 썼나요?
- [x] 작업 목적은 명확하게 의미 전달이 가능한가요?
- [x] 작업 내용은 간결하게 끝나는 문장인가요?
- [x] 첨부는 기능을 충분히 포함하고 있나요?
- [x] 관련 ISSUE나 PR을 포함했나요?
