### PR TITLE
GLOBALNOMAD #54 예약내역 페이지 2차 개발(api)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -23,17 +23,6 @@ const nextConfig: NextConfig = {
 
     return config;
   },
-  images: {
-    remotePatterns: [
-      {
-        protocol: 'https',
-        hostname: 'sprint-fe-project.s3.ap-northeast-2.amazonaws.com',
-        port: '',
-        pathname: '/**',
-        search: '',
-      },
-    ],
-  },
 
   transpilePackages: ['@company/design-system'],
 };

--- a/src/apis/my-reservations.ts
+++ b/src/apis/my-reservations.ts
@@ -1,6 +1,6 @@
 import { axiosInstance } from '@/apis/axios-instance';
 
-export const fetchMyReservations = async (pageParam: null | number) => {
+export const fetchMyReservations = async (pageParam: null | number, queryKey: string[], isFiltered: boolean) => {
   try {
     const token = localStorage.getItem('accessToken');
 
@@ -8,8 +8,10 @@ export const fetchMyReservations = async (pageParam: null | number) => {
       throw new Error('access token을 찾을 수 없음');
     }
 
-    const url = pageParam === null ? `/my-reservations` : `/my-reservations?cursorId=${pageParam}`;
-    // status 추가 필요
+    const cursorUrl = isFiltered ? `/${queryKey}&cursorId=${pageParam}` : `/${queryKey}?cursorId=${pageParam}`;
+    const url = pageParam === null ? `/${queryKey}` : cursorUrl;
+
+    console.log('url: ', url);
 
     const response = await axiosInstance.get(url, {
       headers: {

--- a/src/apis/my-reservations.ts
+++ b/src/apis/my-reservations.ts
@@ -1,0 +1,25 @@
+import { axiosInstance } from '@/apis/axios-instance';
+
+export const fetchMyReservations = async (pageParam: null | number) => {
+  try {
+    const token = localStorage.getItem('accessToken');
+
+    if (!token) {
+      throw new Error('access token을 찾을 수 없음');
+    }
+
+    const url = pageParam === null ? `/my-reservations` : `/my-reservations?cursorId=${pageParam}`;
+    // status 추가 필요
+
+    const response = await axiosInstance.get(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    return response.data;
+  } catch (error) {
+    console.error('fetchMyReservations에서 에러 발생:', error);
+    throw new Error('fetchMyReservations에서 에러 발생');
+  }
+};

--- a/src/app/profile/reservations/history/page.css.ts
+++ b/src/app/profile/reservations/history/page.css.ts
@@ -3,7 +3,7 @@ import { global } from '@/styles/global.css';
 
 export const background = style({
   backgroundColor: `${global.color.gray[100]}`,
-  height: '2000px',
+  height: 'fit-content',
   paddingTop: '80px',
 });
 
@@ -24,7 +24,7 @@ export const panel = style({
 });
 
 export const content = style({
-  width: '100%',
+  width: '792px',
 });
 
 export const contentHeader = style({

--- a/src/app/profile/reservations/history/page.css.ts
+++ b/src/app/profile/reservations/history/page.css.ts
@@ -46,3 +46,7 @@ export const list = style({
   gap: '24px',
   width: '100%',
 });
+
+export const ref = style({
+  height: '5px',
+});

--- a/src/app/profile/reservations/history/page.tsx
+++ b/src/app/profile/reservations/history/page.tsx
@@ -3,14 +3,40 @@
 import DropDownB from '@/components/dropdown/DropDownB';
 import EmptyCard from '@/components/profile/reservations/history/EmptyCard';
 import ReservationCard, { ReservationData } from '@/components/profile/reservations/history/ReservationCard';
-import { DATA } from './mock_data';
+import { useMyReservations } from '@/hooks/use-my-reservations';
+import { useEffect, useRef } from 'react';
 import * as styles from './page.css';
 
 export default function ReservationPage() {
-  const res: ReservationData[] = DATA.reservations;
-  const options = ['예약 신청', '예약 취소', '예약 승인', '예약 거절', '체험 완료'];
-  const isExist = res.length === 0 ? false : true;
+  const { data, fetchNextPage } = useMyReservations();
+  const targetRef = useRef<HTMLDivElement>(null);
 
+  const options = ['예약 신청', '예약 취소', '예약 승인', '예약 거절', '체험 완료'];
+  const isExist = data?.pages[0].totalCount === 0 ? false : true;
+
+  console.log('pages: ', data);
+
+  useEffect(() => {
+    const intersectionObserver = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting) {
+        fetchNextPage(); // 최초 패치 & 옵저버가 관찰되면 추가 패치
+      }
+    });
+
+    const currentTarget = targetRef.current;
+    if (currentTarget) {
+      intersectionObserver.observe(currentTarget);
+    }
+
+    return () => {
+      if (currentTarget) {
+        intersectionObserver.unobserve(currentTarget);
+      }
+    };
+  }, [fetchNextPage]);
+
+  // 드롭다운 필터
+  // 필터 해제: 필터 적용된 인풋창 다시 한번 클릭하면 해제
   const onSelect = (i: string) => {
     console.log(i);
   };
@@ -25,8 +51,17 @@ export default function ReservationPage() {
             {isExist && <DropDownB options={options} placeholder='필터' onSelect={onSelect} />}
           </div>
           <div className={styles.list}>
-            {isExist || <EmptyCard />}
-            {isExist && res.map((data, i) => <ReservationCard data={data} key={i} />)}
+            {isExist || data === undefined || <EmptyCard />}
+            {isExist &&
+              data !== undefined &&
+              data.pages.map((group, i) => (
+                <div className={styles.list} key={i * 100}>
+                  {group.reservations.map((res: ReservationData, j: number) => (
+                    <ReservationCard data={res} key={j} />
+                  ))}
+                </div>
+              ))}
+            {<div className={styles.ref} ref={targetRef} />}
           </div>
         </div>
       </div>

--- a/src/app/profile/reservations/history/page.tsx
+++ b/src/app/profile/reservations/history/page.tsx
@@ -4,11 +4,12 @@ import DropDownB from '@/components/dropdown/DropDownB';
 import EmptyCard from '@/components/profile/reservations/history/EmptyCard';
 import ReservationCard, { ReservationData } from '@/components/profile/reservations/history/ReservationCard';
 import { useMyReservations } from '@/hooks/use-my-reservations';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import * as styles from './page.css';
 
 export default function ReservationPage() {
-  const { data, fetchNextPage } = useMyReservations();
+  const [filter, setFilter] = useState<string | null>(null);
+  const { data, fetchNextPage } = useMyReservations(filter);
   const targetRef = useRef<HTMLDivElement>(null);
 
   const options = ['예약 신청', '예약 취소', '예약 승인', '예약 거절', '체험 완료'];
@@ -33,12 +34,16 @@ export default function ReservationPage() {
         intersectionObserver.unobserve(currentTarget);
       }
     };
-  }, [fetchNextPage]);
+  }, [fetchNextPage, filter]);
 
   // 드롭다운 필터
   // 필터 해제: 필터 적용된 인풋창 다시 한번 클릭하면 해제
   const onSelect = (i: string) => {
-    console.log(i);
+    if (filter == null) {
+      setFilter(i);
+    } else {
+      setFilter(null); // 드롭다운 클릭 x 항목까지 선택해야 동작함... div 한겹 더싸서 onclick으로?
+    }
   };
 
   return (

--- a/src/components/profile/reservations/history/ReservationCard.tsx
+++ b/src/components/profile/reservations/history/ReservationCard.tsx
@@ -1,4 +1,5 @@
 import Modal from '@/components/modal/Modal';
+import { STATUS_STYLE as STATUS } from '@/constants/RESERVATION_STATUS';
 import Image from 'next/image';
 import { useState } from 'react';
 import { createPortal } from 'react-dom';
@@ -30,14 +31,6 @@ export interface ReservationData {
   updatedAt: string;
 }
 
-export const STATUS = {
-  pending: { msg: '예약 신청', color: '#2EB4FF', cancelAvailable: true, reviewAvailable: false },
-  confirm: { msg: '예약 승인', color: '#FF7C1D', cancelAvailable: false, reviewAvailable: false },
-  decline: { msg: '예약 거절', color: '#ff472e', cancelAvailable: false, reviewAvailable: false },
-  canceled: { msg: '예약 취소', color: '#79747E', cancelAvailable: false, reviewAvailable: false },
-  completed: { msg: '체험 완료', color: '#79747E', cancelAvailable: false, reviewAvailable: true },
-};
-
 export default function ReservationCard(props: { data: ReservationData }) {
   const [showCancelModal, setShowCancelModal] = useState(false);
   const handleCancelModalState = () => setShowCancelModal(!showCancelModal);
@@ -53,7 +46,7 @@ export default function ReservationCard(props: { data: ReservationData }) {
   if (
     status === 'pending' ||
     status === 'confirm' ||
-    status === 'decline' ||
+    status === 'declined' ||
     status === 'canceled' ||
     status === 'completed'
   ) {

--- a/src/constants/RESERVATION_STATUS.ts
+++ b/src/constants/RESERVATION_STATUS.ts
@@ -1,0 +1,15 @@
+export const STATUS_STYLE = {
+  pending: { msg: '예약 신청', color: '#2EB4FF', cancelAvailable: true, reviewAvailable: false },
+  confirm: { msg: '예약 승인', color: '#FF7C1D', cancelAvailable: false, reviewAvailable: false },
+  declined: { msg: '예약 거절', color: '#ff472e', cancelAvailable: false, reviewAvailable: false },
+  canceled: { msg: '예약 취소', color: '#79747E', cancelAvailable: false, reviewAvailable: false },
+  completed: { msg: '체험 완료', color: '#79747E', cancelAvailable: false, reviewAvailable: true },
+};
+
+export const STATUS_TRANSLATE = {
+  '예약 신청': 'pending',
+  '예약 승인': 'confirm',
+  '예약 거절': 'declined',
+  '예약 취소': 'canceled',
+  '체험 완료': 'complete',
+};

--- a/src/hooks/use-my-reservations.ts
+++ b/src/hooks/use-my-reservations.ts
@@ -1,10 +1,25 @@
 import { fetchMyReservations } from '@/apis/my-reservations';
+import { STATUS_TRANSLATE } from '@/constants/RESERVATION_STATUS';
 import { useInfiniteQuery } from '@tanstack/react-query';
 
-export const useMyReservations = () => {
+export const useMyReservations = (status: string | null) => {
+  let engStatus = '';
+  let isFiltered = false;
+
+  if (
+    status === '예약 신청' ||
+    status === '예약 승인' ||
+    status === '예약 거절' ||
+    status === '예약 취소' ||
+    status === '체험 완료'
+  ) {
+    isFiltered = true;
+    engStatus = STATUS_TRANSLATE[status];
+  }
+
   return useInfiniteQuery({
-    queryKey: ['my-reservations'],
-    queryFn: ({ pageParam = null }) => fetchMyReservations(pageParam),
+    queryKey: isFiltered ? [`my-reservations?status=${engStatus}`] : ['my-reservations'],
+    queryFn: ({ pageParam = null, queryKey }) => fetchMyReservations(pageParam, queryKey, isFiltered),
     initialPageParam: null,
     getNextPageParam: (lastPage) => {
       return lastPage.cursorId; // 더 없으면 null

--- a/src/hooks/use-my-reservations.ts
+++ b/src/hooks/use-my-reservations.ts
@@ -1,0 +1,14 @@
+import { fetchMyReservations } from '@/apis/my-reservations';
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+export const useMyReservations = () => {
+  return useInfiniteQuery({
+    queryKey: ['my-reservations'],
+    queryFn: ({ pageParam = null }) => fetchMyReservations(pageParam),
+    initialPageParam: null,
+    getNextPageParam: (lastPage) => {
+      return lastPage.cursorId; // 더 없으면 null
+    },
+    staleTime: 1000 * 60,
+  });
+};


### PR DESCRIPTION
## 작업 목적
- 예약내역 페이지 api연결
- 기본/필터, 10개 단위로 추가패치, 무한스크롤 적용

## 작업 내용

- [x] api 연동
- [x] infiniteQuery와 intersectionObserver를 이용한 무한 스크롤
- [x] 드롭다운으로 특정 상태 선택시 필터 적용
- [ ] 필터 해제(디자인 없는데 추가 필요함)

필터해제는 공용 드롭다운 컴포넌트 수정이 필요해서 미뤄두었습니다. 추후 처리하겠습니다.

## 첨부
![예약내역_4](https://github.com/user-attachments/assets/af9f5b6b-a751-4918-9e84-268eb5965ab4)
![예약내역_api1](https://github.com/user-attachments/assets/1db76160-dd91-4479-91de-e4aa12162020)
![예약내역_api2](https://github.com/user-attachments/assets/f44a4c75-c505-44d3-ae1f-55cdaa487e01)

## 관련된 이슈, 커밋, PR
- ISSUE #54 

## 체크리스트

- [x] 빌드 테스트는 하셨나요?
- [x] PR의 내용을 짐작할 수 있는 적절한 제목을 썼나요?
- [x] 작업 목적은 명확하게 의미 전달이 가능한가요?
- [x] 작업 내용은 간결하게 끝나는 문장인가요?
- [x] 첨부는 기능을 충분히 포함하고 있나요?
- [x] 관련 ISSUE나 PR을 포함했나요?

